### PR TITLE
Major refactoring to become more like the original paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,18 @@ iex -S mix
 ```
 
 Then you have to define two functions, `map` and `reduce`, depending on the problem you want to solve.
-Let's say you have a list of connections in the format {source, target} and you want to calculate for each node the list of
-sources that have connections to it. Here's how you can define your map & reduce functions:
+Let's say we want to solve the famous `word count` problem.
+Here's how you can define your map & reduce functions:
 
 ```elixir
-mapper = fn {source, target} -> %{target => [source]} end
-reducer = fn a,b -> %{get_key.(a) => Enum.concat(get_value.(a), get_value.(b))} end
-```
-
-`note`: `get_key` and `get_value` are two functions that assume the given input is a map with only one key and value, and they return the key or value for that map.
-something like this:
-```elixir
-get_key = fn x -> Map.keys(x) |> List.first end
-get_value = fn x -> Map.values(x) |> List.first end
+def mapper({_document, word}), do: [{word, 1}]
+def reducerr({word, values}), do: {word, Enum.reduce(values, 0, fn x, acc -> x + acc end)}
 ```
 
 Then you can use the MapReduce module to calculate the ansewr for your desired list:
 ```elixir
-list = [{1, 3}, {2, 3}, {4, 5}, {5, 6}]
-MapReduce.solve(list, mapper, reducer) # you should get %{3 => [1, 2], 5 => [4], 6 => [5]}
+list = {"hp", "a"}, {"hp", "b"}, {"hp", "a"}, {"hp", "aa"}, {"hp", "a"}
+MapReduce.solve(list, mapper, reducer) # you should get %{"a" => 3, "aa" => 1, "b" => 1} 
 ```
 
 Note that here we used anonymous functions, you can use normal functions but you have to use the syntax `MapReduce.solve(list, &mapper, &reducer)` in that case

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Let's say we want to solve the famous `word count` problem.
 Here's how you can define your map & reduce functions:
 
 ```elixir
-def mapper({_document, word}), do: [{word, 1}]
-def reducerr({word, values}), do: {word, Enum.reduce(values, 0, fn x, acc -> x + acc end)}
+mapper = fn {_document, words} -> Enum.map(words, fn word -> {word, 1} end) end
+reducer = fn {word, values} -> {word, Enum.reduce(values, 0, fn x, acc -> x + acc end)} end
 ```
 
 Then you can use the MapReduce module to calculate the ansewr for your desired list:
 ```elixir
-list = {"hp", "a"}, {"hp", "b"}, {"hp", "a"}, {"hp", "aa"}, {"hp", "a"}
+list = [{"document_name", ["a", "b", "a", "aa", "a"]}]
 MapReduce.solve(list, mapper, reducer) # you should get %{"a" => 3, "aa" => 1, "b" => 1} 
 ```
 

--- a/lib/helper.ex
+++ b/lib/helper.ex
@@ -2,8 +2,6 @@ defmodule Helper do
   require SampleDomains
 
   def get_map_reduce(problem_domain) when is_atom(problem_domain) do
-    domains_pid = elem(GenServer.start(SampleDomains, []), 1)
-
-    GenServer.call(domains_pid, {problem_domain})
+    SampleDomains.map_reduce({problem_domain})
   end
 end

--- a/lib/helper.ex
+++ b/lib/helper.ex
@@ -1,0 +1,9 @@
+defmodule Helper do
+  require SampleDomains
+
+  def get_map_reduce(problem_domain) when is_atom(problem_domain) do
+    domains_pid = elem(GenServer.start(SampleDomains, []), 1)
+
+    GenServer.call(domains_pid, {problem_domain})
+  end
+end

--- a/lib/map_reduce.ex
+++ b/lib/map_reduce.ex
@@ -9,30 +9,43 @@ defmodule MapReduce do
   end
 
   def solve(collection, map_lambda, reduce_lambda, process_count) do
-    worker_pids =
-      Enum.map(1..process_count, fn _ -> GenServer.start(Worker, []) |> elem(1) end)
-      |> List.duplicate(div(length(collection) + process_count - 1, process_count))
-      |> List.flatten()
+    worker_pids = Enum.map(1..process_count, fn _ -> GenServer.start(Worker, []) |> elem(1) end)
 
     collection
     |> Partitioner.partition(process_count)
     |> assign_jobs(worker_pids, process_count, {:map, map_lambda})
     |> List.flatten()
-    |> Enum.group_by(fn x ->
-      Map.keys(x)
-      |> List.first()
+    |> Enum.group_by(fn {key, _value} -> key end)
+    |> Enum.map(fn {k, v} ->
+      {k, Enum.reduce(v, [], fn _x = {_a, b}, acc -> Enum.concat(to_list(b), acc) end)}
     end)
-    |> Map.values()
     |> assign_jobs(worker_pids, process_count, {:reduce, reduce_lambda})
-    |> Enum.reduce(%{}, fn x, acc -> Map.merge(x, acc) end)
+    |> Enum.reduce(%{}, fn {key, values}, acc -> Map.merge(%{key => values}, acc) end)
+  end
+
+  defp to_list(x) when is_list(x) do
+    x
+  end
+
+  defp to_list(x), do: [x]
+
+  def get_hash_for({key, _value}) do
+    :crypto.hash(:sha, to_string(key)) |> Base.encode16() |> Integer.parse(16) |> elem(0)
+  end
+
+  def get_hash_for(_partition = [{key, _value} | _t]) do
+    :crypto.hash(:sha, to_string(key)) |> Base.encode16() |> Integer.parse(16) |> elem(0)
   end
 
   def assign_jobs(partitions, worker_pids, process_count, {job_type, lambda})
       when is_atom(job_type) do
     partitions
-    |> Enum.zip(worker_pids)
     |> Task.async_stream(
-      fn {parition, worker_pid} -> GenServer.call(worker_pid, {job_type, parition, lambda}) end,
+      fn partition ->
+        worker_id = get_hash_for(partition) |> Integer.mod(length(worker_pids))
+        worker_pid = Enum.at(worker_pids, worker_id)
+        GenServer.call(worker_pid, {job_type, partition, lambda})
+      end,
       max_concurrency: process_count,
       ordered: false
     )

--- a/lib/map_reduce.ex
+++ b/lib/map_reduce.ex
@@ -1,6 +1,5 @@
 defmodule MapReduce do
   require SampleDomains
-  require Partitioner
   require Worker
   require Randomizer
 
@@ -12,7 +11,6 @@ defmodule MapReduce do
     worker_pids = Enum.map(1..process_count, fn _ -> GenServer.start(Worker, []) |> elem(1) end)
 
     collection
-    |> Partitioner.partition(process_count)
     |> assign_jobs(worker_pids, process_count, {:map, map_lambda})
     |> List.flatten()
     |> Enum.group_by(fn {key, _value} -> key end)

--- a/lib/partitioner.ex
+++ b/lib/partitioner.ex
@@ -1,14 +1,4 @@
 defmodule Partitioner do
-  def start_link do
-    Task.start_link(fn -> loop() end)
-  end
-
-  defp loop() do
-    receive do
-      {:partition, list, parts_count, pid} -> send(pid, partition(list, parts_count))
-    end
-  end
-
   def partition(list, parts_count) when is_list(list) do
     Enum.chunk_every(list, ceil(length(list) / parts_count))
   end

--- a/lib/partitioner.ex
+++ b/lib/partitioner.ex
@@ -1,9 +1,0 @@
-defmodule Partitioner do
-  def partition(list, parts_count) when is_list(list) do
-    Enum.chunk_every(list, ceil(length(list) / parts_count))
-  end
-
-  def partition(%Range{} = range, parts_count) do
-    partition(range |> Enum.to_list(), parts_count)
-  end
-end

--- a/lib/partitioner.ex
+++ b/lib/partitioner.ex
@@ -4,13 +4,6 @@ defmodule Partitioner do
   end
 
   def partition(%Range{} = range, parts_count) do
-    range_len = range.last - range.first + 1
-    single_instance_len = ceil(range_len / parts_count)
-
-    Stream.iterate(
-      range.first..(single_instance_len + range.first - 1),
-      &((&1.last + 1)..min(range.last, &1.last + single_instance_len))
-    )
-    |> Enum.take(parts_count)
+    partition(range |> Enum.to_list(), parts_count)
   end
 end

--- a/lib/sample_problem_domains.ex
+++ b/lib/sample_problem_domains.ex
@@ -1,15 +1,15 @@
 defmodule SampleDomains do
   require Randomizer
 
-  def dict_reducer({word, values}), do: {word, Enum.reduce(values, 0, fn x, acc -> x + acc end)}
+  def word_reducer({word, values}), do: {word, Enum.reduce(values, 0, fn x, acc -> x + acc end)}
 
-  def dict_mapper({_document, word}), do: [{word, 1}]
+  def word_mapper({_document, words}), do: Enum.map(words, fn word -> {word, 1} end)
 
-  def map_reduce({:word_count}), do: {&dict_mapper/1, &dict_reducer/1}
+  def map_reduce({:word_count}), do: {&word_mapper/1, &word_reducer/1}
 
   def map_reduce({:page_rank}), do: {&link_mapper/1, &link_reducer/1}
 
-  def link_mapper({source, target}), do: [{target, [source]}]
+  def link_mapper({source, targets}), do: Enum.map(targets, fn target -> {target, source} end)
 
   def link_reducer({key, values}),
     do: {key, Enum.reduce(values, [], fn x, acc -> Enum.concat([x], acc) end)}

--- a/lib/sample_problem_domains.ex
+++ b/lib/sample_problem_domains.ex
@@ -1,19 +1,16 @@
 defmodule SampleDomains do
   require Randomizer
 
-  def dict_reducer(x, y), do: %{get_key(x) => get_value(y) + get_value(x)}
+  def dict_reducer({word, values}), do: {word, Enum.reduce(values, 0, fn x, acc -> x + acc end)}
 
-  defp get_key(x), do: Map.keys(x) |> List.first()
+  def dict_mapper({_document, word}), do: [{word, 1}]
 
-  defp get_value(x), do: Map.values(x) |> List.first()
+  def map_reduce({:word_count}), do: {&dict_mapper/1, &dict_reducer/1}
 
-  def dict_mapper(x), do: %{x => 1}
+  def map_reduce({:page_rank}), do: {&link_mapper/1, &link_reducer/1}
 
-  def map_reduce({:word_count}), do: {&dict_mapper/1, &dict_reducer/2}
+  def link_mapper({source, target}), do: [{target, [source]}]
 
-  def map_reduce({:page_rank}), do: {&link_mapper/1, &link_reducer/2}
-
-  def link_mapper({source, target}), do: %{target => [source]}
-
-  def link_reducer(a, b), do: %{get_key(a) => Enum.concat(get_value(a), get_value(b))}
+  def link_reducer({key, values}),
+    do: {key, Enum.reduce(values, [], fn x, acc -> Enum.concat([x], acc) end)}
 end

--- a/lib/sample_problem_domains.ex
+++ b/lib/sample_problem_domains.ex
@@ -1,6 +1,5 @@
 defmodule SampleDomains do
   require Randomizer
-  use GenServer
 
   def dict_reducer(x, y), do: %{get_key(x) => get_value(y) + get_value(x)}
 
@@ -10,21 +9,9 @@ defmodule SampleDomains do
 
   def dict_mapper(x), do: %{x => 1}
 
-  def init(_args) do
-    {:ok, %{}}
-  end
+  def map_reduce({:word_count}), do: {&dict_mapper/1, &dict_reducer/2}
 
-  def handle_call({:word_count}, _from, _state) do
-    {:reply, {&dict_mapper/1, &dict_reducer/2}, %{}}
-  end
-
-  def handle_call({:get_sample_list, :word_count}, _from, _state) do
-    {:reply, Randomizer.randomizer(3, 1_000), %{}}
-  end
-
-  def handle_call({:page_rank}, _from, _state) do
-    {:reply, {&link_mapper/1, &link_reducer/2}, %{}}
-  end
+  def map_reduce({:page_rank}), do: {&link_mapper/1, &link_reducer/2}
 
   def link_mapper({source, target}), do: %{target => [source]}
 

--- a/lib/sample_problem_domains.ex
+++ b/lib/sample_problem_domains.ex
@@ -2,31 +2,19 @@ defmodule SampleDomains do
   require Randomizer
   use GenServer
 
-  def dict_reducer(x, y) do
-    %{
-      get_key(x) => get_value(y) + get_value(x)
-    }
-  end
+  def dict_reducer(x, y), do: %{get_key(x) => get_value(y) + get_value(x)}
 
-  defp get_key(x) do
-    Map.keys(x)
-    |> List.first()
-  end
+  defp get_key(x), do: Map.keys(x) |> List.first()
 
-  defp get_value(x) do
-    Map.values(x)
-    |> List.first()
-  end
+  defp get_value(x), do: Map.values(x) |> List.first()
 
-  def dict_mapper(x) do
-    %{x => 1}
-  end
+  def dict_mapper(x), do: %{x => 1}
 
   def init(_args) do
     {:ok, %{}}
   end
 
-  def handle_call({:word_count, _pid}, _from, _state) do
+  def handle_call({:word_count}, _from, _state) do
     {:reply, {&dict_mapper/1, &dict_reducer/2}, %{}}
   end
 
@@ -38,11 +26,7 @@ defmodule SampleDomains do
     {:reply, {&link_mapper/1, &link_reducer/2}, %{}}
   end
 
-  def link_mapper({source, target}) do
-    %{target => [source]}
-  end
+  def link_mapper({source, target}), do: %{target => [source]}
 
-  def link_reducer(a, b) do
-    %{get_key(a) => Enum.concat(get_value(a), get_value(b))}
-  end
+  def link_reducer(a, b), do: %{get_key(a) => Enum.concat(get_value(a), get_value(b))}
 end

--- a/lib/worker.ex
+++ b/lib/worker.ex
@@ -9,17 +9,11 @@ defmodule Worker do
     {:noreply, %{state | elements: elements}}
   end
 
-  def handle_call({:reduce, array, reducer}, _from, state) do
-    {:reply,
-     to_list(array)
-     |> Enum.reduce(fn x, acc -> reducer.(acc, x) end), state}
+  def handle_call({:reduce, {key, values}, reducer}, _from, state) do
+    {:reply, reducer.({key, values}), state}
   end
 
   def handle_call({:map, array, mapper}, _from, state) do
     {:reply, Enum.map(array, mapper), state}
   end
-
-  defp to_list(%Range{} = range), do: Enum.to_list(range)
-
-  defp to_list(list) when is_list(list), do: list
 end

--- a/lib/worker.ex
+++ b/lib/worker.ex
@@ -9,11 +9,11 @@ defmodule Worker do
     {:noreply, %{state | elements: elements}}
   end
 
-  def handle_call({:reduce, {key, values}, reducer}, _from, state) do
-    {:reply, reducer.({key, values}), state}
+  def handle_call({:reduce, key_values, reducer}, _from, state) do
+    {:reply, reducer.(key_values), state}
   end
 
-  def handle_call({:map, array, mapper}, _from, state) do
-    {:reply, Enum.map(array, mapper), state}
+  def handle_call({:map, key_value, mapper}, _from, state) do
+    {:reply, mapper.(key_value), state}
   end
 end

--- a/lib/worker.ex
+++ b/lib/worker.ex
@@ -19,11 +19,7 @@ defmodule Worker do
     {:reply, Enum.map(array, mapper), state}
   end
 
-  defp to_list(%Range{} = range) do
-    Enum.to_list(range)
-  end
+  defp to_list(%Range{} = range), do: Enum.to_list(range)
 
-  defp to_list(list) when is_list(list) do
-    list
-  end
+  defp to_list(list) when is_list(list), do: list
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,8 @@ defmodule MapReduce.MixProject do
       elixir: "~> 1.11.4",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      escript: [main_module: MapReduce]
+      escript: [main_module: MapReduce],
+      xref: [exclude: [:crypto]]
     ]
   end
 

--- a/test/map_reduce_test.exs
+++ b/test/map_reduce_test.exs
@@ -7,7 +7,7 @@ defmodule MapReduceTest do
 
   test "word_count" do
     {map, reduce} = Helper.get_map_reduce(:word_count)
-    collection = ["a", "b", "a", "aa", "a"]
+    collection = [{"hp", "a"}, {"hp", "b"}, {"hp", "a"}, {"hp", "aa"}, {"hp", "a"}]
 
     assert collection |> MapReduce.solve(map, reduce, 1) == %{
              "a" => 3,
@@ -17,14 +17,18 @@ defmodule MapReduceTest do
   end
 
   test "word_total_count" do
-    process_count = 400
-    total_word_count = 500_000
-    words = Randomizer.randomizer(7, total_word_count)
+    process_count = 50
+    total_word_count = 100_000
+
+    words =
+      Randomizer.randomizer(7, total_word_count)
+      |> Enum.map(fn word -> {"hp", word} end)
 
     {map, reduce} = Helper.get_map_reduce(:word_count)
 
     result_count =
       MapReduce.solve(words, map, reduce, process_count)
+      |> IO.inspect()
       |> Enum.reduce(0, fn {_k, v}, acc -> v + acc end)
 
     assert(result_count == total_word_count)

--- a/test/map_reduce_test.exs
+++ b/test/map_reduce_test.exs
@@ -28,7 +28,6 @@ defmodule MapReduceTest do
 
     result_count =
       MapReduce.solve(words, map, reduce, process_count)
-      |> IO.inspect()
       |> Enum.reduce(0, fn {_k, v}, acc -> v + acc end)
 
     assert(result_count == total_word_count)

--- a/test/map_reduce_test.exs
+++ b/test/map_reduce_test.exs
@@ -29,6 +29,11 @@ defmodule MapReduceTest do
     {map, reduce} = GenServer.call(pid, {:page_rank})
     connections = [{1, 3}, {2, 3}, {4, 5}, {5, 6}]
 
-    assert(MapReduce.solve(connections, map, reduce) == %{3 => [1, 2], 5 => [4], 6 => [5]})
+    result =
+      MapReduce.solve(connections, map, reduce)
+      |> Enum.map(fn {k, v} -> {k, Enum.sort(v)} end)
+      |> Map.new()
+
+    assert(result == %{3 => [1, 2], 5 => [4], 6 => [5]})
   end
 end

--- a/test/map_reduce_test.exs
+++ b/test/map_reduce_test.exs
@@ -2,10 +2,14 @@ defmodule MapReduceTest do
   use ExUnit.Case
   require Partitioner
   require Randomizer
+  require Helper
   doctest MapReduce
 
   test "word_count" do
-    assert MapReduce.solve(:word_count, 1, ["a", "b", "a", "aa", "a"]) == %{
+    {map, reduce} = Helper.get_map_reduce(:word_count)
+    collection = ["a", "b", "a", "aa", "a"]
+
+    assert collection |> MapReduce.solve(map, reduce, 1) == %{
              "a" => 3,
              "aa" => 1,
              "b" => 1
@@ -17,16 +21,17 @@ defmodule MapReduceTest do
     total_word_count = 500_000
     words = Randomizer.randomizer(7, total_word_count)
 
+    {map, reduce} = Helper.get_map_reduce(:word_count)
+
     result_count =
-      MapReduce.solve(:word_count, process_count, words)
+      MapReduce.solve(words, map, reduce, process_count)
       |> Enum.reduce(0, fn {_k, v}, acc -> v + acc end)
 
     assert(result_count == total_word_count)
   end
 
   test "page_rank" do
-    pid = GenServer.start(SampleDomains, []) |> elem(1)
-    {map, reduce} = GenServer.call(pid, {:page_rank})
+    {map, reduce} = Helper.get_map_reduce(:page_rank)
     connections = [{1, 3}, {2, 3}, {4, 5}, {5, 6}]
 
     result =


### PR DESCRIPTION
changes (some sentences are used from the MapReduce [whitepaper](https://static.googleusercontent.com/media/research.google.com/en//archive/mapreduce-osdi04.pdf)):

1. use hashing for keys to decide which solver to use for each collection
2. `map` takes an input pair and produces a set of intermediate key/value pairs
3. `reduce` accepts an intermediate key I and a set of values for that key. It merges together these values to form a possibly smaller set of values